### PR TITLE
fix for purify css plugin

### DIFF
--- a/webpack.parts.js
+++ b/webpack.parts.js
@@ -139,7 +139,7 @@ exports.purifyCSS = function(paths) {
         paths: paths.map(path => `${path}/*`),
         // Walk through only html files within node_modules. It
         // picks up .js files by default!
-        resolveExtensions: ['.html']
+        resolveExtensions: ['.html', '.js']
       }),
     ]
   }


### PR DESCRIPTION
added '.js' as item under resolveExtensions property for purifyCssPlugin. This is to fix - https://github.com/survivejs-demos/webpack-demo/issues/2 

This could be because we are using styles within the js file. However, it may not be the best fix because the size reduced from ~15 kb to ~12 kb only. 